### PR TITLE
Change current year from 2014 -> 2018

### DIFF
--- a/apps/issf_base/templates/issf_base/base.html
+++ b/apps/issf_base/templates/issf_base/base.html
@@ -225,7 +225,7 @@
         <footer>
             <div class="row">
                 <div class="large-8 columns">
-                    <p class="copy">&copy;2014 TBTI, all rights reserved. Hosted by
+                    <p class="copy">&copy;2018 TBTI, all rights reserved. Hosted by
                         <a
                                 href="http://www.mun.ca/research/resources/computing/creait-isg/index.php"
                                 target="_blank">CREAIT-ISG


### PR DESCRIPTION
# What
Currently the footer contains an incorrect date for copyright.

# Test
Open any page with footer, footer should be different.

###### It really is `current_year`