### PR TITLE
Updated old dory.creait.mun.ca URL to current URL

### DIFF
--- a/apps/details/templates/details/details.html
+++ b/apps/details/templates/details/details.html
@@ -208,8 +208,7 @@
                 {#                        {% autoescape off %}#}
                 <table>
                     {% for external_link in external_links %}
-                        <tr>
-                            <td>{{ external_link.link_type }}</td>
+                        <tr> <td>{{ external_link.link_type }}</td>
                             <td>
                                 <a href="{{ external_link.link_address }}"
                                    target="_blank">{{ external_link.link_address }}</a>
@@ -241,7 +240,7 @@
     <div class="large-3 columns">
         {#            domain hard-coded because request.get_host broke under https #}
         <div class="fb-comments"
-             data-href="https://dory.creait.mun.ca{% url 'sota-details' issf_core_id=core_instance.issf_core_id %}"
+             data-href="https://issfcloud.toobigtoignore.net{% url 'sota-details' issf_core_id=core_instance.issf_core_id %}"
              data-width="220" data-numposts="3" data-colorscheme="light"></div>
     </div>
     </div>

--- a/apps/details/templates/details/details.html
+++ b/apps/details/templates/details/details.html
@@ -208,7 +208,8 @@
                 {#                        {% autoescape off %}#}
                 <table>
                     {% for external_link in external_links %}
-                        <tr> <td>{{ external_link.link_type }}</td>
+                        <tr> 
+                            <td>{{ external_link.link_type }}</td>
                             <td>
                                 <a href="{{ external_link.link_address }}"
                                    target="_blank">{{ external_link.link_address }}</a>

--- a/apps/details/templates/details/record_report.html
+++ b/apps/details/templates/details/record_report.html
@@ -319,7 +319,7 @@
                     </p>
                     <a href="{{ url }}" style="color:#055bb7;">
                         <strong>
-                            https://dory.creait.mun.ca{{ url }}
+                            https://issfcloud.toobigtoignore.net.ca{{ url }}
                         </strong>
                     </a>
                     <p style="margin-top: 10px;">

--- a/apps/details/templates/details/ssf_case_study_details.html
+++ b/apps/details/templates/details/ssf_case_study_details.html
@@ -335,7 +335,7 @@
                 <div class="large-3 columns">
                     {#            domain hard-coded because request.get_host broke under https #}
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'experiences-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'experiences-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light"></div>
                 </div>
                 {% if editor %}

--- a/apps/details/templates/details/ssfcapacity_details.html
+++ b/apps/details/templates/details/ssfcapacity_details.html
@@ -292,7 +292,7 @@
                     {#            <div class="fb-comments" data-href="{{ request.get_host }}{% url 'capacity-details' issf_core_id=core_instance.issf_core_id %}" data-width="220" data-numposts="3" data-colorscheme="light"></div>#}
                     {#            domain hard-coded because request.get_host broke under https #}
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'capacity-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'capacity-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light"></div>
                 </div>
                 {% if editor %}

--- a/apps/details/templates/details/ssfexperiences_details.html
+++ b/apps/details/templates/details/ssfexperiences_details.html
@@ -263,7 +263,7 @@
                 <div class="large-3 columns">
                     {#            domain hard-coded because request.get_host broke under https #}
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'experiences-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'experiences-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light"></div>
                 </div>
                 {% if editor %}

--- a/apps/details/templates/details/ssfguidelines_details.html
+++ b/apps/details/templates/details/ssfguidelines_details.html
@@ -304,7 +304,7 @@
                 </div>
                 <div class="large-3 columns">
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'guidelines-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'guidelines-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light"></div>
                 </div>
                 {% if editor %}

--- a/apps/details/templates/details/ssfknowledge_details.html
+++ b/apps/details/templates/details/ssfknowledge_details.html
@@ -914,7 +914,7 @@
                 <div class="large-3 columns">
                     {#            domain hard-coded because request.get_host broke under https #}
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'sota-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'sota-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light"></div>
                 </div>
                 {% if editor %}

--- a/apps/details/templates/details/ssforganization_details.html
+++ b/apps/details/templates/details/ssforganization_details.html
@@ -774,7 +774,7 @@
                 <div class="large-3 columns">
                     {#            domain hard-coded because request.get_host broke under https #}
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'organization-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'organization-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light"></div>
                 </div>
                 {% if editor %}

--- a/apps/details/templates/details/ssfperson_details.html
+++ b/apps/details/templates/details/ssfperson_details.html
@@ -657,7 +657,7 @@
                     {% endif %}
                     {#            domain hard-coded because request.get_host broke under https #}
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'who-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'who-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light">
                     </div>
                 </div>

--- a/apps/details/templates/details/ssfprofile_details.html
+++ b/apps/details/templates/details/ssfprofile_details.html
@@ -670,7 +670,7 @@
                         </li>
                     </ul>
                     <div class="fb-comments"
-                         data-href="https://dory.creait.mun.ca{% url 'profile-details' issf_core_id=core_instance.issf_core_id %}"
+                         data-href="https://issfcloud.toobigtoignore.net{% url 'profile-details' issf_core_id=core_instance.issf_core_id %}"
                          data-width="220" data-numposts="3" data-colorscheme="light"></div>
                 </div>
             </div>

--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -777,7 +777,7 @@ def save_basic(request, model_class, form_class):
 
                     issf_id = str(instance.issf_core_id)
 
-                    url = 'https://dory.creait.mun.ca' + reverse(get_redirectname(instance.core_record_type),
+                    url = 'https://issfcloud.toobigtoignore.net' + reverse(get_redirectname(instance.core_record_type),
                                                                  kwargs={'issf_core_id': issf_id})
 
                     api.PostUpdate(
@@ -952,7 +952,7 @@ def sota_basic(request):
 
                     api.PostUpdate(
                         'Check out the new #tbtiissf SOTA record for ' + name + '. ' +
-                        'https://dory.creait.mun.ca/details/sota/' + issf_id)
+                        'https://issfcloud.toobigtoignore.net/details/sota/' + issf_id)
 
                 update_tsvector_summary(knowledge_instance.core_record_type,
                                         str(knowledge_instance.pk))
@@ -1076,7 +1076,7 @@ def organization_basic(request):
 
                 api.PostUpdate(
                     'Check out the new #tbtiissf SSF Organization record for ' + name + '. ' +
-                    'https://dory.creait.mun.ca/details/organization/' + issf_id)
+                    'https://issfcloud.toobigtoignore.net/details/organization/' + issf_id)
 
                 update_tsvector_summary(instance.core_record_type,
                                         str(instance.pk))


### PR DESCRIPTION
Changes over remaining usage of the "dory.creait.mun.ca" URL to the current URL. This most importantly addresses the issue of incorrect URLs on Twitter in Issue #16 