### PR TITLE
Remove outdated reference to old django js reversing framework

### DIFF
--- a/apps/issf_admin/templates/issf_admin/user_profile.html
+++ b/apps/issf_admin/templates/issf_admin/user_profile.html
@@ -1,4 +1,4 @@
-{% extends "issf_base/base.html" %}{% load js %}{% load staticfiles %}
+{% extends "issf_base/base.html" %}
 
 {% load staticfiles %}
 {% load foundation %}
@@ -33,7 +33,6 @@
 {% endblock body %}
 
 {% block additional_js_scripts %}
-    {% django_js jquery=false %}
     <script src={% static "details/js/error-handling.js" %}></script>
     <script>
         error_handler();


### PR DESCRIPTION
This pull request is incomplete. 

Currently, it addresses Issue #59, but in its current state it introduces a new bug whereby when a user is editing their user profile at URL `/account/profile`, hitting "Submit" appears to do nothing. The text of the button changes to "Please Wait" with no confirmation of completion. 

This issue of having a broken "Submit" button is also documented in Issue #11 at a different page on the site. This may indicate the button code is flawed.

The expected behaviour as currently outlined on production is to be sent to a new URL `/accounts/profile-saved/` which contains the confirmation text "Thank you for updating your User Profile."