### PR TITLE
Fixed TypeError at /details/who (Issue #66)

### DIFF
--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -224,7 +224,7 @@ def sota_details(request, issf_core_id):
 def who_details(request, issf_core_id):
     # person and related instances
     profile_form = None
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         profile_form = ProfileForm(instance=request.user)
     person_instance = SSFPerson.objects.get(issf_core_id=issf_core_id)
     core_instance = ISSF_Core.objects.get(issf_core_id=issf_core_id)


### PR DESCRIPTION
Backend code was originally calling is_authenticated, however is_authenticated is a variable. Removed the brackets causing it to be called, which resolved the type error.