### PR TITLE
Blacklisted brackets from being used in the search

### DIFF
--- a/apps/frontend/views.py
+++ b/apps/frontend/views.py
@@ -29,7 +29,7 @@ def parse_search_terms(input_search_terms):
         and the search to hang.
     """
 
-    for char in ":'|!&%\"":
+    for char in ":'|!&%\"()":
         input_search_terms = input_search_terms.replace(char, " ")
     search_array = input_search_terms.split()
     for idx in range(0, len(search_array)):


### PR DESCRIPTION
Brackets being used in the search bar cause the search to never finish (causing the behavior seen in #93). This PR adds brackets to the banned characters, hopefully resolving that issue.