### PR TITLE
Add PDF generation abilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,12 @@ ENV PYTHONUNBUFFERED 1
 RUN apt-get update
 RUN apt-get -y install --allow-unauthenticated dialog apt-utils realpath coreutils libgeos-dev \
     gdal-bin binutils libproj-dev build-essential python-sphinx pylint \
-    libxss1 libappindicator1 wget virtualenv
+    libxss1 libappindicator1 wget virtualenv gconf-service libasound2 \
+    libatk1.0-0 libcairo2 libcups2 libfontconfig1 libgdk-pixbuf2.0-0 \
+    libgtk-3-0 libnspr4 libpango-1.0-0 libxss1 fonts-liberation \
+    libappindicator3-1 libnss3 lsb-release xdg-utils
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install
 
 RUN mkdir /issf/
 ADD requirements.txt /issf

--- a/apps/details/templates/details/record_report.html
+++ b/apps/details/templates/details/record_report.html
@@ -18,6 +18,12 @@
                 <img id="issf-logo" class="float-right" src="{% static 'issf_base/img/logo-issf.png' %}">
             </div>
 
+            <div class="row hidefromprint" onclick="window.open('/details/report-pdf/profile/{{ id }}');">
+                <div class="section-header" id="downloadaspdf">
+                    <h2>Download as PDF</h2>
+                </div>
+            </div>
+
             <div class="row">
                 <div id="title">
                     <h1>{{ record.ssf_name }}</h1>
@@ -25,7 +31,7 @@
             </div>
 
             <div class="row">
-                <div id="section-header">
+                <div class="section-header">
                     <h2>At a Glance</h2>
                 </div>
             </div>
@@ -77,7 +83,7 @@
                     </div>
                 {% endif %}
                 <div class="seven columns">
-                    <div id="section-header">
+                    <div class="section-header">
                         <h2>SSF Definition</h2>
                     </div>
 
@@ -88,7 +94,7 @@
                         No definition provided.
                     {% endif %}
                     </div>
-                    <div id="section-header">
+                    <div class="section-header">
                         <h2>Distribution Channels</h2>
                     </div>
                     <div class="twelve columns">
@@ -107,7 +113,7 @@
 
             <div class="row">
                 <div class="twelve columns">
-                    <div id="section-header">
+                    <div class="section-header">
                         <h2>Key Species & Landings</h2>
                     </div>
 
@@ -140,9 +146,10 @@
 
             <div class="row">
                 <div class="four columns">
-                    <div id="section-header">
+                    <div class="section-header">
                         <h2>Major Issues</h2>
                     </div>
+
                     <div id="major-issues">
                         {% if issues %}
                             {% for issue in issues %}
@@ -159,7 +166,7 @@
                 </div>
 
                 <div class="eight columns">
-                    <div id="section-header">
+                    <div class="section-header">
                         <h2>Key Rules & Regulations</h2>
                     </div>
 
@@ -188,7 +195,7 @@
                         </h4>
                     </div>
 
-                    <div id="section-header">
+                    <div class="section-header">
                         <h2>Non-fishing Livelihood Activities</h2>
                     </div>
 
@@ -220,7 +227,7 @@
                         </div>
                     </div>
 
-                    <div id="footer-flower">
+                    <div id="footer-flower" class="hidefromprint">
                         <div>
                             <img src="{% static 'issf_base/img/TBTIflower.png' %}"/>
                         </div>
@@ -230,7 +237,7 @@
 
             <div class="row">
                 <div class="four columns">
-                    <div id="section-header">
+                    <div class="section-header">
                         <h2>Governance</h2>
                     </div>
                     <div>
@@ -290,7 +297,7 @@
                 </div>
             </div>
 
-            <div class="row">
+            <div class="row hidefromprint">
                 <div>
                     <img src="{% static 'issf_base/img/TBTImedia.png' %}"/>
                 </div>

--- a/apps/details/urls.py
+++ b/apps/details/urls.py
@@ -92,6 +92,10 @@ urlpatterns = [  # display
         r'?P<issf_core_id>\d+)/$',
         report,
         name='report'),
+    url(r'^report-pdf/(?P<record_type>\w+)/('
+        r'?P<issf_core_id>\d+)/$',
+        render_report_pdf,
+        name='report-pdf'),
 
     url(r'^delete/(?P<issf_core_id>\d+)/$', delete_record,
         name='delete-record'),

--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -1,7 +1,7 @@
 import ast
 import json
 import re
-from io import BytesIO
+import tempfile
 from urllib.parse import urlparse
 import collections
 
@@ -25,7 +25,7 @@ from issf_admin.views import save_profile
 
 import twitter
 import twitter.error
-import xhtml2pdf.pisa as pisa
+import hardcopy
 from issf_prod.settings import TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET
 from issf_prod.settings import TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET
 
@@ -1809,12 +1809,9 @@ def render_report_pdf(request, record_type, issf_core_id):
     """
     template = get_template("details/record_report.html")
     html = template.render(generate_report(record_type, issf_core_id))
-    response = BytesIO()
-    pdf = pisa.pisaDocument(BytesIO(html.encode("UTF-8")), response)
-    if not pdf.err:
-        return HttpResponse(response.getvalue(), content_type='application/pdf')
-    else:
-        return HttpResponse("Error Rendering PDF", status=400)
+    with tempfile.NamedTemporaryFile(suffix=".pdf") as f:
+        hardcopy.bytestring_to_pdf(html.encode("utf8"), f)
+        return HttpResponse(f.read(), content_type='application/pdf')
 
 
 def get_record_type(record_type):

--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -1,6 +1,7 @@
 import ast
 import json
 import re
+from io import BytesIO
 from urllib.parse import urlparse
 import collections
 
@@ -10,6 +11,7 @@ from django.core.cache import cache
 from django.urls import reverse
 from django.db import connection
 from django.forms.utils import ErrorList
+from django.template.loader import get_template
 from django.http import HttpResponseNotFound, HttpResponse
 from django.shortcuts import get_object_or_404, render, redirect
 from django.views.generic import CreateView
@@ -23,6 +25,7 @@ from issf_admin.views import save_profile
 
 import twitter
 import twitter.error
+import xhtml2pdf.pisa as pisa
 from issf_prod.settings import TWITTER_ACCESS_TOKEN, TWITTER_ACCESS_TOKEN_SECRET
 from issf_prod.settings import TWITTER_CONSUMER_KEY, TWITTER_CONSUMER_SECRET
 
@@ -1650,7 +1653,10 @@ some refactoring. I made this when I was short on time.
 """
 
 
-def report(request, record_type, issf_core_id):
+def generate_report(record_type, issf_core_id):
+    """
+    Handles the retrieval and generation of data to be used in reports.
+    """
     record = SSFProfile.objects.get(issf_core_id=issf_core_id)
     core_instance = ISSF_Core.objects.get(issf_core_id=issf_core_id)
     main_attributes = MainAttributeView.objects.filter(issf_core=issf_core_id)
@@ -1767,27 +1773,48 @@ def report(request, record_type, issf_core_id):
     else:
         who_page = None
 
+    return {
+        'record': record,
+        'location': location,
+        'zoom': zoom_level,
+        'distribution': distribution,
+        'attrs': dict(attrs),
+        'species_colors': species_colors,
+        'colors': colors,
+        'issues': issues,
+        'key_rules_regs': krr,
+        'hh_income': hh_income,
+        'governance': gov_modes,
+        'non_fish_act': non_fish_act,
+        'url': record_url,
+        'who_page': who_page,
+        'num_fishers': num_fishers
+    }
+
+
+def report(request, record_type, issf_core_id):
+    """
+    Renders a webpage containing a report on a given item.
+    """
     return render(
         request,
         'details/record_report.html',
-        {
-            'record': record,
-            'location': location,
-            'zoom': zoom_level,
-            'distribution': distribution,
-            'attrs': dict(attrs),
-            'species_colors': species_colors,
-            'colors': colors,
-            'issues': issues,
-            'key_rules_regs': krr,
-            'hh_income': hh_income,
-            'governance': gov_modes,
-            'non_fish_act': non_fish_act,
-            'url': record_url,
-            'who_page': who_page,
-            'num_fishers': num_fishers
-        }
+        generate_report(record_type, issf_core_id)
     )
+
+
+def render_report_pdf(request, record_type, issf_core_id):
+    """
+    Renders a report for a given item and returns it to the user as a PDF.
+    """
+    template = get_template("details/record_report.html")
+    html = template.render(generate_report(record_type, issf_core_id))
+    response = BytesIO()
+    pdf = pisa.pisaDocument(BytesIO(html.encode("UTF-8")), response)
+    if not pdf.err:
+        return HttpResponse(response.getvalue(), content_type='application/pdf')
+    else:
+        return HttpResponse("Error Rendering PDF", status=400)
 
 
 def get_record_type(record_type):

--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -1774,6 +1774,7 @@ def generate_report(record_type, issf_core_id):
         who_page = None
 
     return {
+        'id': issf_core_id,
         'record': record,
         'location': location,
         'zoom': zoom_level,

--- a/issf_prod/settings.py
+++ b/issf_prod/settings.py
@@ -180,3 +180,4 @@ ROOT_URLCONF = 'issf_prod.urls'
 WSGI_APPLICATION = 'issf_prod.wsgi_dev.application'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 POSTGIS_VERSION = (2, 1)
+CHROME_PATH = "google-chrome"

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,4 +42,4 @@ six==1.10.0
 tablib==0.10.0
 unicodecsv==0.14.1
 Unipath==1.1
-xhtml2pdf==0.2.3
+django-hardcopy==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ flickrapi==2.1.2
 foundationform==0.2
 future==0.16.0
 gunicorn==19.9.0
-html5lib==0.999
+html5lib==1.0.1
 httplib2==0.9.2
 oauth==1.0.1
 oauth2==1.9.0.post1
@@ -42,3 +42,4 @@ six==1.10.0
 tablib==0.10.0
 unicodecsv==0.14.1
 Unipath==1.1
+xhtml2pdf==0.2.3

--- a/static_root/reports/css/recordreport.css
+++ b/static_root/reports/css/recordreport.css
@@ -13,6 +13,14 @@ h2 {
     font-size: 2em;
 }
 
+h3 {
+    font-size: 2em;
+}
+
+h4 {
+    font-size: 1.75em;
+}
+
 h1,
 h2,
 h3,
@@ -28,7 +36,15 @@ h4 {
     width: 100%;
 }
 
-#section-header,
+#downloadaspdf {
+    background:  #f16a2c;
+}
+
+#downloadaspdf:hover {
+    background:  #ff9666;
+}
+
+.section-header,
 #contributor {
     background-color: #001871;
     border-radius: 0.25em;
@@ -37,7 +53,7 @@ h4 {
     margin: 1.2em 0;
 }
 
-#section-header h2 {
+.section-header h2 {
     margin: 0;
     color: white;
 }
@@ -107,6 +123,10 @@ td {
         font-size: 0.8em;
     }
 
+    .hidefromprint {
+        display: none;
+    }
+
     #piechart {
         min-height: 100%;
         max-width: 100%;
@@ -115,14 +135,14 @@ td {
         width: auto !important;
     }
 
-    #section-header,
+    .section-header,
     #contributor {
         border: 1px solid black;
         background: white;
         box-shadow: none;
     }
 
-    #section-header h2,
+    .section-header h2,
     #contributor h2 {
         color: black;
     }

--- a/static_root/reports/css/recordreport.css
+++ b/static_root/reports/css/recordreport.css
@@ -119,7 +119,12 @@ td {
 }
 
 @media print {
+    @page {
+        margin: 16px;
+    }
+
     body {
+        margin: 1.6cm;
         font-size: 0.8em;
     }
 

--- a/static_root/reports/js/recordreport.js
+++ b/static_root/reports/js/recordreport.js
@@ -10,6 +10,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
         data: values,
         backgroundColor: colors
       }]
+    },
+    options: {
+      animation: {
+        duration: 0,
+      },
+      legend: {
+        labels: {
+          fontSize: 10
+        }
+      }
     }
   });
 });


### PR DESCRIPTION
Adds a new route, /details/report-pdf, that functions the same as /details/report, but instead generates a PDF of the report, complete with things such as unfilled headers to reduce wasted ink (thanks @jackharrhy!)

Example:

![](https://i.bootleg.technology/NG4dT8ZJWe.png)