### PR TITLE
Fix export

### DIFF
--- a/apps/frontend/templates/frontend/index.html
+++ b/apps/frontend/templates/frontend/index.html
@@ -1902,7 +1902,7 @@
                     type: "POST",
                     url: "{% url 'data-export' %}",
                     dataType: "json",
-                    data: {'ids': currentRecords},
+                    data: {'ids': currentRecords, csrfmiddlewaretoken: document.getElementsByName('csrfmiddlewaretoken')[0].value},
                     complete: function () {
                         window.location.replace("{% url 'data-export' %}");
                     }

--- a/export/README within exported zip files.txt
+++ b/export/README within exported zip files.txt
@@ -1,0 +1,31 @@
+TBTI ISSF resources and data are available to support your research or other non-commercial purposes.
+
+Please ensure that the proper credits are given when using those resources. When using TBTI ISSF
+
+content in any format, including print or web publications, presentations, grant applications, websites,
+
+other online applications, you must provide appropriate acknowledgements using a citation consistent
+
+with the following standard:
+
+1- When referring to various datasets downloaded from the website, and/or its concept or design,
+
+or to several datasets extracted from its underlying databases, use the following citation.
+
+Example: “Chuenpagdee R. and Devillers R. (Editors). 2015. Information System on Small-Scale Fisheries.
+
+Too Big to Ignore – Global Partnership for Small-Scale Fisheries. Accessible on
+
+www.issf.toobigtoignore.net.”
+
+2- When referring to a set of values extracted from a given profile, cite the contributor named on
+
+that profile.
+
+Example: For the Pontal do Paraná – Brazil Small-scale fisheries Profile, the citation should be: “Leis,
+
+M.O. 2015. Pontal do Paraná – Brazil Small-scale fisheries Profile. Information System on Small-Scale
+
+Fisheries. Too Big to Ignore – Global Partnership for Small-Scale Fisheries. Accessible on
+
+www.issf.toobigtoignore.net.”

--- a/issf_prod/settings.py
+++ b/issf_prod/settings.py
@@ -180,3 +180,5 @@ ROOT_URLCONF = 'issf_prod.urls'
 WSGI_APPLICATION = 'issf_prod.wsgi_dev.application'
 SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 POSTGIS_VERSION = (2, 1)
+
+DATA_UPLOAD_MAX_NUMBER_FIELDS = 4096


### PR DESCRIPTION
Export function before had the path of the old server within itself,
therefore it was not working in the container.

These changes still have hard coded paths, except this time:
- The paths are to do with the container, which should be more stable.
- The tabledata.zip file is stored in the /tmp/ dir instead of the
project folder.

The CSRF token is also sent to the server in the POST request, this must
have been due to a Django 2.0 change.

Also, the files are only now going to save themselves in the base folder, rather than being in the same directory structure as they are on the server.