### PR TITLE
Choropleth hover bug

### DIFF
--- a/apps/frontend/templates/frontend/index.html
+++ b/apps/frontend/templates/frontend/index.html
@@ -1195,6 +1195,7 @@
             }
 
             function resetHighlight(e) {
+                var layer = e.target;
                 geojson.setStyle(style);
                 choroControl.update(layer.feature.properties);
             }

--- a/apps/frontend/templates/frontend/index.html
+++ b/apps/frontend/templates/frontend/index.html
@@ -1224,7 +1224,7 @@
             };
 
             function formatChoroProp(x, sep, grp) {
-                if (x === "-") return "No Data";
+                if (!x || x === "-") return "No Data";
                 if (x.length > 3) {
                     var sx = ('' + Math.round(x)).split('.'), s = '', i, j;
                     sep || (sep = ','); // default seperator


### PR DESCRIPTION
This fixes the problem of choroControl reporting incorrect names while hovering in layers other than the initial one

It also fixes a small error that occurs every time the user hovers over any country
`Uncaught TypeError: Cannot read property 'properties' of undefined
    at NewClass.resetHighlight ((index):4018)
    at NewClass.fireEvent (leaflet-src.js:461)
    at NewClass._fireMouseEvent (leaflet-src.js:4750)
    at SVGGElement.handler [as _leaflet_mouseout6847] (leaflet-src.js:6403)`

Also here's another good one liner: **Did you hear about the crook who stole a calendar? He got twelve months.**