### PR TITLE
Fixed missing whitespace in recent contributions by country block on index

### DIFF
--- a/apps/frontend/templates/frontend/index.html
+++ b/apps/frontend/templates/frontend/index.html
@@ -439,7 +439,7 @@
                                         {{ contribution.contribution_count }} contributions
                                     </li>
                                 {% endfor %}
-                                <li><strong>Countries with one contribution:</strong>{{ other_countries.count }}</li>
+                                <li><strong>Countries with one contribution:</strong> {{ other_countries.count }}</li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Before:

![](https://i.bootleg.technology/5LSgvwOF1O.png)

After:

![](https://i.bootleg.technology/jWEialbiny.png)