### PR TITLE
Refactor PDF reports

### DIFF
--- a/apps/details/templates/details/record_report.html
+++ b/apps/details/templates/details/record_report.html
@@ -18,11 +18,13 @@
                 <img id="issf-logo" class="float-right" src="{% static 'issf_base/img/logo-issf.png' %}">
             </div>
 
+            <!-- https://github.com/toobigtoignore/issf/issues/160
             <div class="row hidefromprint" onclick="window.open('/details/report-pdf/profile/{{ id }}');">
                 <div class="section-header" id="downloadaspdf">
                     <h2>Download as PDF</h2>
                 </div>
             </div>
+            -->
 
             <div class="row">
                 <div id="title">

--- a/apps/details/templates/details/ssfprofile_details.html
+++ b/apps/details/templates/details/ssfprofile_details.html
@@ -596,26 +596,16 @@
 
                     <a
                         id="report-btn"
-                        href="/details/report/profile/{{ profile_instance.issf_core_id }}"
-                        class="button radius {% if profile_instance.percent < 70 %}disabled-link has-tip{% endif %}"
-                        {% if profile_instance.percent < 70 %}data-tooltip aria-haspopup='true'
-                        title='Profiles must be at least 70% complete to generate a report.'{% endif %}
-                        style="margin-left: 42px; width:145px;"
-                    >
-                        View Report
-                    </a>
-
-                    <a
-                        id="report-btn"
                         href="/details/report-pdf/profile/{{ profile_instance.issf_core_id }}"
                         class="button radius {% if profile_instance.percent < 70 %}disabled-link has-tip{% endif %}"
                         {% if profile_instance.percent < 70 %}data-tooltip aria-haspopup='true'
                         title='Profiles must be at least 70% complete to generate a report.'{% endif %}
                         style="margin-left: 42px; width:145px;"
                     >
-                        Download Report As PDF
+                        View As PDF
                     </a>
 
+                    <!-- https://github.com/toobigtoignore/issf/issues/139
                     <a
                         target="_blank"
                         href="http://demo.vista.cs.uregina.ca/gcpc-ssf/"
@@ -624,6 +614,7 @@
                     >
                         Compare Profiles
                     </a>
+                    -->
 
                     <ul style="font-size: 0.85rem;">
                         <li>

--- a/static_root/reports/css/recordreport.css
+++ b/static_root/reports/css/recordreport.css
@@ -4,8 +4,8 @@ body {
 }
 
 h1 {
-    margin-top: 0.4em;
-    font-size: 3em;
+    margin: 0.4em 0 0 0;
+    font-size: 2.75em;
     font-weight: bold;
 }
 
@@ -50,7 +50,7 @@ h4 {
     border-radius: 0.25em;
     padding: 0.4em;
     box-shadow: 0 3px 3px 2px #ccc;
-    margin: 1.2em 0;
+    margin: 0.6em 0;
 }
 
 .section-header h2 {
@@ -75,7 +75,7 @@ td {
 }
 
 #piechart {
-    margin: 0 auto;
+    margin: -0.5em auto 0 auto;
 }
 
 #key-species div {
@@ -142,7 +142,7 @@ td {
 
     .section-header,
     #contributor {
-        border: 1px solid black;
+        border: 1px solid #222;
         background: white;
         box-shadow: none;
     }


### PR DESCRIPTION
Resolves #160.
Resolves #161.
Resolves #139.
Kinda touches #132 a bit.

## What

- Remove 'View Report' button
- Hide 'Compare Profile' button
- Hide 'Download as PDF' button from report itself
- Slight-css fixes to improve sizing of document