### PR TITLE
Remove old js tag from admin only pages

### DIFF
--- a/apps/frontend/templates/frontend/country_records.html
+++ b/apps/frontend/templates/frontend/country_records.html
@@ -1,5 +1,4 @@
 {% extends "issf_base/base.html" %}
-
 {% load url from future %}
 {% load staticfiles %}
 {% load foundation %}
@@ -16,8 +15,7 @@ Country Records for {{country_name}}
 {% block body %}
 <div class="row">
     <div class="large-12 columns page-title2">
-        <!-- page title ------->
-        <h1>ISSF Records for {{country_name}}</h1>
+        <h1>Country Records for {{country_name}}</h1>
     </div>
 </div>
 <div class="row">

--- a/apps/frontend/templates/frontend/geojson_upload.html
+++ b/apps/frontend/templates/frontend/geojson_upload.html
@@ -1,5 +1,4 @@
 {% extends 'issf_base/base.html' %}
-{% load js %}
 {% load staticfiles %}
 
 {% block additional_css_scripts %}

--- a/apps/frontend/templates/frontend/new_tip.html
+++ b/apps/frontend/templates/frontend/new_tip.html
@@ -1,5 +1,4 @@
 {% extends 'issf_base/base.html' %}
-{% load js %}
 {% load staticfiles %}
 
 {% block additional_css_scripts %}

--- a/apps/frontend/templates/frontend/who_feature.html
+++ b/apps/frontend/templates/frontend/who_feature.html
@@ -1,5 +1,4 @@
 {% extends 'issf_base/base.html' %}
-{% load js %}
 {% load staticfiles %}
 
 {% block additional_css_scripts %}


### PR DESCRIPTION
Resolves #171 

## What

Admin pages currently throw template errors, this fixes that.

## Why

Old django js tag removal.

## Testing

Pages now work.

## Notes

Backend may still not accept data, but everything seems find / no 500 internal server errors on hitting submit.
