### PR TITLE
Changed password change form to prevent crashing

### DIFF
--- a/apps/issf_admin/templates/issf_admin/account/password_change.html
+++ b/apps/issf_admin/templates/issf_admin/account/password_change.html
@@ -16,7 +16,7 @@
             &nbsp;
             <form method="POST" action="{% url 'account_change_password' %}" class="password_change">
                 {% csrf_token %}
-                {{ form|foundation }}
+                {{ form }}
                 {% if redirect_field_value %}
                     <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
                 {% endif %}


### PR DESCRIPTION
Resolves #154 

## What
Changed the password change form from `{{ form|template }}` to `{{ form }}`


## Why
Solves a crash related to the upgrade from Django 1.10


## Testing
1. Log in as catfish
2. Click catfish in the top right
3. Click change password

The password change form should be displayed, instead of an error.

