### PR TITLE
Removed an extra greater than symbol

### DIFF
--- a/apps/issf_base/templates/issf_base/base.html
+++ b/apps/issf_base/templates/issf_base/base.html
@@ -48,7 +48,7 @@
          gtag('js', new Date());
       
          gtag('config', 'UA-130630934-1');
-        </script>>
+        </script>
 
         <script type="text/javascript">
             function googleTranslateElementInit() {


### PR DESCRIPTION
Corrected `</script>>` to `</script>`

## What
Corrected `</script>>` to `</script>`, removing a grey bar from the top of the screen


## Why
That grey bar was not supposed to be there


## Testing
Go to the site, notice that there is no longer a grey bar there.

