### PR TITLE
Fix TypeError preventing logout

### DIFF
--- a/apps/issf_admin/views.py
+++ b/apps/issf_admin/views.py
@@ -2,8 +2,9 @@ import json
 import random
 
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth import logout
 from django.urls import reverse
-from django.shortcuts import render, HttpResponse
+from django.shortcuts import render, HttpResponse, HttpResponseRedirect
 from django.db import connection
 from allauth.account.models import EmailAddress
 from allauth.account.views import PasswordChangeView
@@ -99,6 +100,11 @@ class CustomPasswordChangeView(PasswordChangeView):
 
 
 custom_password_change = login_required(CustomPasswordChangeView.as_view())
+
+
+def logout_view(request):
+    logout(request)
+    return HttpResponseRedirect('/')
 
 
 def return_google_site_verification(request):

--- a/apps/issf_base/templates/issf_base/base.html
+++ b/apps/issf_base/templates/issf_base/base.html
@@ -146,10 +146,8 @@
                                     </li>
                                 {% endif %}
                             </ul>
+                            ｜
                         {% endif %}
-
-                        ｜
-
                         <span
                             data-tooltip aria-haspopup="true" class="has-tip"
                             title="ISSF Help Page" style="padding-left: 3px;"

--- a/issf_prod/urls.py
+++ b/issf_prod/urls.py
@@ -1,7 +1,6 @@
 from issf_admin.views import return_sitemap, return_robots, return_google_site_verification, update_profile, \
-    profile_saved, account_verified, custom_password_change, help_page, fact_archive, contributed_records
+    profile_saved, account_verified, custom_password_change, help_page, fact_archive, contributed_records, logout_view
 
-from django.contrib.auth import logout
 from frontend.views import new_tip, new_faq, who_feature, geojson_upload, index, table_data_export, profile_csv, country_records
 
 from django.conf.urls import include, url
@@ -16,7 +15,7 @@ urlpatterns = [
     url(r'^googlee9690f8983b8a350.html/$', return_google_site_verification, name="return-google-site-verification"),
 
     # auth
-    url(r'^accounts/logout/$', logout, {'next_page': '/'}),
+    url(r'^accounts/logout/$', logout_view),
     url(r'^accounts/profile/$', update_profile, name="update-profile"),
     url(r'^accounts/profile-saved/$', profile_saved, name='profile-saved'),
     url(r'^accounts/verified/$', account_verified, name="account-verified"),


### PR DESCRIPTION
Resolves #188 

## What
Changes the logout function to use a custom logout view, rather than trying to call a function that isn't a view. Additionally, removes a duplicate pipe for logged out users.


## Why
Allows users to logout, and makes the menu in the top right look cleaner for logged out users.


## Testing
1. Login as catfish
2. Ensure the pipes in the top right look correct
3. Click catfish, and then logout
4. Ensure the user was logged out, and the pipes in the top right still look correct.

