### PR TITLE
Made front-page report link go to a pdf report rather than the now hidden webpage report

### DIFF
--- a/apps/frontend/templates/frontend/index.html
+++ b/apps/frontend/templates/frontend/index.html
@@ -630,7 +630,7 @@
 
                             <li>
                                 <strong>Explore</strong> SSF characteristics through charts, tables, and infographics
-                                with <a href="{% url 'report' 'profile' 2288 %}" target="_blank">SSF Profile Reports</a>
+                                with <a href="{% url 'report-pdf' 'profile' 2288 %}" target="_blank">SSF Profile Reports</a>
                             </li>
 
                             <!--


### PR DESCRIPTION
## What
Updated the following link to go to a pdf report, rather than the old webpage report.

![](https://i.bootleg.technology/TmGebAeLlm.png)


## Why
Webpage reports are no longer accessible, and no longer actively maintained, and as a result using this link as an example of a report is not necessarily representative of the current state of reports.


## Testing
1. Go to the front page
2. Click the link from the screenshot
You should be taken to a pdf, rather than a webpage.

