### PR TITLE
Made docker_nuke be slightly more precise, to reduce the amount of collateral damage

### DIFF
--- a/scripts/docker_nuke.sh
+++ b/scripts/docker_nuke.sh
@@ -9,6 +9,6 @@
 # removing them and building them again from the downloaded image is
 # the solution.
 
-docker-compose stop
-docker-compose rm -fv
-docker system prune -a
+docker-compose down --rmi all --volumes --remove-orphans
+docker system prune
+


### PR DESCRIPTION
Resolves #42 

## What
Changes docker_nuke to first use docker-compose to nuke project-related images, volumes, and containers, and *then* docker system purge to clean up anything left over, rather than using docker system purge to nuke everything on the system.


## Why
This should reduce the amount of unrelated containers deleted by docker nuke.


## Testing
1. Run `docker-compose up -d`
2. Run `./scripts/docker_nuke.sh`
3. Run `docker image ls`
You should notice that there is still a python image there, as that is a common image that is not specifically used by just us.

