### PR TITLE
Fixed TemplateSyntaxError when attempting to load changelog page

### DIFF
--- a/apps/details/templates/details/changelog.html
+++ b/apps/details/templates/details/changelog.html
@@ -2,7 +2,6 @@
 
 {% extends "issf_base/base.html" %}
 
-{% load url from future %}
 {% load staticfiles %}
 {% load foundation %}
 {% load i18n %}


### PR DESCRIPTION
Resolves #198 

## What
Removed an unnecessary tag from the changelog page, allowing it to be loaded again.


## Why
Pages that give errors are never a good time, even if they are never linked to from anywhere.


## Testing
Go to /details/changelogs. Changelogs should be displayed instead of an error message.

