### PR TITLE
Fixed error with type hinting, as well as being able to create faq entries while not staff

### DIFF
--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -670,7 +670,7 @@ def case_study_details(request: HttpRequest, issf_core_id: int) -> HttpResponse:
 # END DETAILS VIEWS
 
 
-def get_other_theme_issue(themes_issues_form: ThemesIssuesForm, field: str, issf_core_id: int, theme_issue_value_id: int) -> None:
+def get_other_theme_issue(themes_issues_form, field: str, issf_core_id: int, theme_issue_value_id: int) -> None:
     """
     Unused function to set values in a given themes and issues form based on data already stored in the database.
     """
@@ -1380,7 +1380,7 @@ def themes_issues(request: HttpRequest) -> HttpResponse:
                 return HttpResponse(response)
 
 
-def save_other_theme_issue(themes_issues_form: ThemesIssuesForm, field: str, issf_core_id: int, theme_issue_value_id: int) -> None:
+def save_other_theme_issue(themes_issues_form, field: str, issf_core_id: int, theme_issue_value_id: int) -> None:
     """
     Saves 'other' values for theme/issue forms.
     """

--- a/apps/frontend/views.py
+++ b/apps/frontend/views.py
@@ -13,7 +13,7 @@ from django.core.management import call_command
 from django.db.models import QuerySet
 from django.contrib.gis.db.models import Model
 from django.urls import reverse
-from django.http import HttpResponse, HttpResponseRedirect, Http404, HttpRequest
+from django.http import HttpResponse, HttpResponseRedirect, Http404, HttpRequest, HttpResponseForbidden
 from django.shortcuts import render
 from django.template import Context
 from djgeojson.views import GeoJSONLayerView
@@ -873,7 +873,7 @@ def new_tip(request: HttpRequest) -> HttpResponse:
             }
         )
     else:
-        raise Http404("Insufficient permission.")
+        raise HttpResponseForbidden("Insufficient permission.")
 
 
 @login_required()
@@ -884,12 +884,15 @@ def new_faq(request: HttpRequest) -> HttpResponse:
     """
 
     if request.method == 'POST':
-        form = FAQForm(request.POST)
+        if request.user.is_staff:
+            form = FAQForm(request.POST)
 
-        if form.is_valid():
-            form.save()
+            if form.is_valid():
+                form.save()
 
-        return HttpResponseRedirect(reverse('new-tip'))
+            return HttpResponseRedirect(reverse('new-tip'))
+        else:
+            raise HttpResponseForbidden("Insufficient permission.")
 
 
 @login_required()


### PR DESCRIPTION
## What
Added check to ensure that a user is staff before creating a faq entry, and removed a type hint that was making the main page unable to be displayed (introduced by #205)


## Why
People who lack the permission should not be allowed to submit new FAQ entries, but the site should always be able to load.


