### PR TITLE
Fixed tweet checkboxes appearing in places that they shouldn't

### DIFF
--- a/apps/details/forms.py
+++ b/apps/details/forms.py
@@ -192,7 +192,11 @@ class SSFCapacityNeedForm(ModelForm):
     """
 
     # Custom field for supressing tweets
-    tweet = forms.BooleanField(initial=False, required=False)
+    tweet = forms.BooleanField(
+        initial=False,
+        required=False,
+        label="Staff only: Prevent tweeting to @TBTInetwork"
+    )
 
     class Meta:
         model = SSFCapacityNeed
@@ -318,7 +322,11 @@ class SSFCaseStudiesForm(ModelForm):
     """
 
     # Custom field for supressing tweets
-    tweet = forms.BooleanField(initial=False, required=False)
+    tweet = forms.BooleanField(
+        initial=False,
+        required=False,
+        label="Staff only: Prevent tweeting to @TBTInetwork"
+    )
 
     class Meta:
         model = SSFCaseStudies

--- a/apps/details/templates/details/contribute.html
+++ b/apps/details/templates/details/contribute.html
@@ -693,14 +693,6 @@
                                             {{ case_study_form }}
                                         </div>
 
-                                        {% if user.is_staff %}
-                                            <div class="staffbox">
-                                                <h5>Staff only:</h5>
-                                                <label style="padding-right: 5px;">Prevent posting to @TBTInetwork on Twitter</label>
-                                                {{ case_study_form.tweet }}
-                                            </div>
-                                        {% endif %}
-
                                         <div class="button-bar">
                                             <button class="medium bt-submit " value="Submit">
                                                 Submit
@@ -735,14 +727,6 @@
                                         <div class="FormSet">
                                             {{ capacity_need_form }}
                                         </div>
-
-                                        {% if user.is_staff %}
-                                            <div class="staffbox">
-                                                <h5>Staff only:</h5>
-                                                <label style="padding-right: 5px;">Prevent posting to @TBTInetwork on Twitter</label>
-                                                {{ capacity_need_form.tweet }}
-                                            </div>
-                                        {% endif %}
 
                                         <div class="button-bar">
                                             <button class="medium bt-submit " value="Submit">

--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -107,6 +107,13 @@ def contribute(request: HttpRequest, who: str = '') -> HttpResponse:
     if who == 'who':
         is_active = 'active'
 
+    case_study_form = SSFCaseStudiesForm(initial={'contributor': request.user.id})
+    capacity_need_form = SSFCapacityNeedForm(initial={'contributor': request.user.id})
+
+    if not request.user.is_staff:
+        del case_study_form.fields['tweet']
+        del capacity_need_form.fields['tweet']
+
     return render(
         request,
         "details/contribute.html",
@@ -118,11 +125,11 @@ def contribute(request: HttpRequest, who: str = '') -> HttpResponse:
             "organization_form": SSFOrganizationForm(prefix="org", initial={'contributor': request.user.id}),
             "knowledge_form": SSFKnowledgeForm(initial={'contributor': request.user.id}),
             "knowledge_authors_form": AuthorsInlineFormSet,
-            "capacity_need_form": SSFCapacityNeedForm(initial={'contributor': request.user.id}),
+            "capacity_need_form": capacity_need_form,
             "fishery_profile_form": SSFProfileForm(initial={'contributor': request.user.id, 'data_end_year': 0}),
             "guidelines_form": SSFGuidelinesForm(initial={'contributor': request.user.id}),
             "experiences_form": SSFExperiencesForm(initial={'contributor': request.user.id}),
-            "case_study_form": SSFCaseStudiesForm(initial={'contributor': request.user.id}),
+            "case_study_form": case_study_form,
             "is_active": is_active
         }
     )
@@ -355,6 +362,7 @@ def capacity_details(request: HttpRequest, issf_core_id: int) -> HttpResponse:
 
     # forms
     capacity_need_form = SSFCapacityNeedForm(instance=capacity_need_instance)
+    del capacity_need_form.fields['tweet']
     geographic_scope_form = GeographicScopeForm(instance=core_instance)
     local_area_form = GeographicScopeLocalAreaInlineFormSet(instance=core_instance)
     subnation_form = GeographicScopeSubnationInlineFormSet(instance=core_instance)
@@ -622,6 +630,7 @@ def case_study_details(request: HttpRequest, issf_core_id: int) -> HttpResponse:
 
     # forms
     case_study_form = SSFCaseStudiesForm(instance=case_studies_instance)
+    del case_study_form.fields['tweet']
     geographic_scope_form = GeographicScopeForm(instance=core_instance)
     local_area_form = GeographicScopeLocalAreaInlineFormSet(instance=core_instance)
     subnation_form = GeographicScopeSubnationInlineFormSet(instance=core_instance)


### PR DESCRIPTION
Resolves #206 

## What
* Removed duplicate tweet checkboxes for case study and capacity development forms
* Made tweet checkboxes for those only display if you are staff
* Removed tweet checkboxes from case study and capacity development edit forms


## Why
We don't need that many checkboxes.


## Testing
1. Log in as catfish
2. Make catfish not staff
3. Try to create a capacity development or case study record
There should be no option to prevent tweeting now.

