### PR TITLE
Added script to automatically run collect static on file change

### DIFF
--- a/scripts/web_collectstatic.sh
+++ b/scripts/web_collectstatic.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+while true; do
+    inotifywait -r static_root/ && docker-compose exec -T web \
+    /bin/sh -c 'python manage.py collectstatic --noinput'
+done


### PR DESCRIPTION
Resolves #203 

## What
Adds a new script (`./scripts/web_collectstatic.sh`), that automatically runs collectstatic in the web container whenever anything under `static_root` changes.


## Why
Allows devs to work on the software and make changes to static assets without having to run collectstatic every time.


## Testing
1. Install `inotify-tools`
2. Run `./scripts/web_collectstatic.sh`
3. Edit a file under static_root
You should see console output from collectstatic being ran.

