### PR TITLE
Fixed error with updating user profile

### DIFF
--- a/static_root/details/js/error-handling.js
+++ b/static_root/details/js/error-handling.js
@@ -106,10 +106,14 @@ function error_handler() {
                         var redirectURL;
 
                         if (jsonData.record === null) {
-                          // Urls[...] returns null if no argument
-                          redirectURL = Urls[jsonData.redirectname]('');
-                          // Giving an empty string returns a extra / at end of URL, this removes it
-                          redirectURL = redirectURL.substr(0,a.length-1);
+                          if (jsonData.redirectname === 'profile-saved') {
+                            redirectURL = Urls[jsonData.redirectname]();
+                          } else {
+                            // Urls[...] returns null if no argument
+                            redirectURL = Urls[jsonData.redirectname]('');
+                            // Giving an empty string returns a extra / at end of URL, this removes it
+                            redirectURL = redirectURL.substr(0,a.length-1);
+                          }
                         } else {
                           redirectURL = Urls[jsonData.redirectname](jsonData.record);
                         }


### PR DESCRIPTION
Resolves #195 

## What
Changes how the error handling code retrieves the redirect URL.


## Why
Makes changing user profile details actually work.


## Testing
Try changing profile details, see that it does in fact no longer burst into a giant ball of flame when you click submit.

