### PR TITLE
Improve PDF report styling

### DIFF
--- a/static_root/reports/css/recordreport.css
+++ b/static_root/reports/css/recordreport.css
@@ -119,6 +119,10 @@ td {
 }
 
 @media print {
+    #header img {
+        height: 32px;
+    }
+
     @page {
         margin: 16px;
     }
@@ -138,17 +142,5 @@ td {
         max-height: 100%;
         height: auto !important;
         width: auto !important;
-    }
-
-    .section-header,
-    #contributor {
-        border: 1px solid #222;
-        background: white;
-        box-shadow: none;
-    }
-
-    .section-header h2,
-    #contributor h2 {
-        color: black;
     }
 }


### PR DESCRIPTION
## What

Removed CSS to do with making the PDF more print friendly.
Made img smaller on top.

![image](https://user-images.githubusercontent.com/6486417/50566550-a2e67f80-0d15-11e9-9f45-14732e1f62ec.png)


## Why

User can make b&w, but most might just send reports via email so we gucci.