### PR TITLE
Fixed internal server error when trying to generate a pdf report for a regional record

### DIFF
--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -1979,7 +1979,7 @@ def generate_report(record_type: str, issf_core_id: int) -> Dict[str, Any]:
     if core_instance.geographic_scope_type == 'Regional':
         geog_scope = geographic_scope_region
         for geo_record in geographic_scope_region:
-            location = geo_record.country.short_name
+            location = geo_record.region.region_name
         zoom_level = 3
     elif core_instance.geographic_scope_type == 'National':
         geog_scope = geographic_scope_nation

--- a/apps/issf_base/models.py
+++ b/apps/issf_base/models.py
@@ -1299,7 +1299,7 @@ class Geographic_Scope_Region(models.Model):
 
         :return: The string representation.
         """
-        return '%s' % (self.country.region_name)
+        return '%s' % (self.region.region_name)
 
 
 class SiteVersion(models.Model):


### PR DESCRIPTION
## What
Changes regions to use the region name for the name of the region rather than the country name.

## Why
Continent != Country

## Testing
Generate a PDF report for a regional geographic scope record (such as ID 3554)

