### PR TITLE
comma not needed for "Other" location, modify zoom

### DIFF
--- a/apps/details/views.py
+++ b/apps/details/views.py
@@ -1976,8 +1976,8 @@ def generate_report(record_type: str, issf_core_id: int) -> Dict[str, Any]:
     location = ''
     if core_instance.geographic_scope_type == 'Regional':
         for geo_record in geographic_scope_region:
-            location = geo_record.region.region_name + ", "
-        zoom_level = 3
+            location = geo_record.region.region_name
+        zoom_level = 1
     elif core_instance.geographic_scope_type == 'National':
         for geo_record in geographic_scope_nation:
             location = geo_record.country.short_name + ", "


### PR DESCRIPTION
## What
- removed comma for regional locations
- changed zoom to show more of earth for regional locations

## Why
- "Other," looks worse than "Other"
- should show the entire globe; ex. if a region is Mediterranean, a map of North America is not appropriate



## Testing
- checked multiple regional profiles to confirm intended change works


